### PR TITLE
Check height on full text render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,11 +100,16 @@ export default class ClampLines extends PureComponent {
       this.middle = Math.floor((this.start + this.end) / 2);
       this.element.innerText = this.original.slice(0, this.middle);
       if (this.middle === this.original.length) {
-        this.setState({
-          text: this.original,
-          noClamp: true,
-        });
-        return;
+        if (this.element.clientHeight <= maxHeight) {
+          this.setState({
+            text: this.original,
+            noClamp: true,
+          });
+          return;
+        } else {
+          this.middle = this.original.length - 1;
+          break;          
+        }
       }
 
       this.moveMarkers(maxHeight);


### PR DESCRIPTION
With `word-break: break-all`, sometimes the last character in a string can be enough to trigger a line wrap.

So when the clampLines() loop has decided to show the full string, check the height one last time. And if we wrapped, just remove the last char from the displayed string.